### PR TITLE
kson format v0.3.0

### DIFF
--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version: `0.3.0-beta1`)
+# KSON Format Specification (version: `0.3.0-beta2`)
 - Encoding: UTF-8 (without BOM), LF
 - If a default value is specified in this document, undefined values are overwritten by the default value.
 - `null` value is not allowed in the entire kson file.
@@ -20,6 +20,7 @@ dictionary kson {
     AudioInfo?    audio;       // audio-related data
     CameraInfo?   camera;      // camera-related data
     BgInfo?       bg;          // background-related data
+    EditorInfo?   editor;      // (OPTIONAL) data used only in editors
     ImplInfo?     impl;        // (OPTIONAL) implementation-dependent options for each client
 }
 ```
@@ -60,12 +61,9 @@ dictionary BeatInfo {
     ByPulse<double>[] bpm;                        // bpm changes
     ByMeasureIndex<TimeSig>[]? time_sig;          // time signature changes
                                                   // this is used for drawing bar lines and audio effects
-    Interval[]? stop;                             // stop events
-    ByPulse<double>[]? scroll_speed;              // (OPTIONAL) scroll speed changes (default: 1.0)
+    GraphPoint[]? scroll_speed;                   // scroll speed changes (default: 1.0)
 }
 ```
-- Two or more stops cannot be overlapped. To make the chart scroll backwards, set `scroll_speed` to a negative value instead.
-- `stop` has a higher priority than `scroll_speed`.
 
 ### `beat.time_sig`
 ```
@@ -734,6 +732,15 @@ dictionary KshLayerRotationInfo {
 dictionary KshMovie {
     DOMString? filename;  // self-explanatory
     long offset = 0;      // movie offset in millisecond
+}
+```
+
+-----------------------------------------------------------------------------------
+
+### `editor` (OPTIONAL)
+```
+dictionary EditorInfo {
+    ByPulse<DOMString>? comment;  // (OPTIONAL) comments that can be written in the editor
 }
 ```
 

--- a/kson_format.md
+++ b/kson_format.md
@@ -2,7 +2,7 @@
 - Encoding: UTF-8 (without BOM), LF
 - If a default value is specified in this document, undefined values are overwritten by the default value.
 - `null` value is not allowed in the entire kson file.
-- Support for parameters/options marked "(OPTIONAL)" are optional, but must be ignored if not supported.
+- Support for parameters/options marked "(OPTIONAL)" is optional, but must be ignored if not supported.
 - `xxx` and `...` denote placeholders.
 - The resolution of pulse value (`y`) is 240 per beat (i.e., 960 per measure).
 - The behavior for illegal values is undefined, and kson clients do not necessarily need to report an error even if there is an illegal value.

--- a/kson_format.md
+++ b/kson_format.md
@@ -690,23 +690,23 @@ dictionary BgInfo {
 ### `bg.legacy` (OPTIONAL)
 ```
 dictionary LegacyBgInfo {
-    KshBg[2]? bg;        // first element: when gauge < 70%, second element: when gauge >= 70%
-    KshLayer? layer;
-    KshMovie? movie;
+    KshBgInfo[2]? bg;        // first element: when gauge < 70%, second element: when gauge >= 70%
+    KshLayerInfo? layer;
+    KshMovieInfo? movie;
 }
 ```
 - If `bg` has only a single element, that bg is always used, regardless of the percentage of the gauge.
 
-#### `bg.legacy.bg[]` (OPTIONAL)
+#### `bg.legacy.bg[xxx]` (OPTIONAL)
 ```
-dictionary KshBg {
+dictionary KshBgInfo {
     DOMString filename = "desert";  // self-explanatory (can be KSM default BG image such as "`desert`")
 }
 ```
 
 #### `bg.legacy.layer` (OPTIONAL)
 ```
-dictionary KshLayer {
+dictionary KshLayerInfo {
     DOMString filename = "arrow";    // self-explanatory (can be KSM default animation layer such as "`arrow`")
     long duration = 0;               // one-loop duration in milliseconds
                                      //   If the value is negative, the animation is played backwards.
@@ -725,7 +725,7 @@ dictionary KshLayerRotationInfo {
 
 #### `bg.legacy.movie` (OPTIONAL)
 ```
-dictionary KshMovie {
+dictionary KshMovieInfo {
     DOMString? filename;  // self-explanatory
     long offset = 0;      // movie offset in millisecond
 }

--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version: `0.3.0-beta7`)
+# KSON Format Specification (version: `0.3.0-beta8`)
 - Encoding: UTF-8 (without BOM), LF
 - If a default value is specified in this document, undefined values are overwritten by the default value.
 - `null` value is not allowed in the entire kson file.
@@ -397,6 +397,7 @@ Parameter values are written in one of the following formats:
         - Additional requirement:
             - The formats `[float]ms` and `[float]s` are not allowed.
         - `0`: Automatic trigger update is disabled.
+        - This parameter allows kson clients to use only the OnMin value and ignore the Off and OnMax values.
         - Note: `update_period` interval count is reset at the beginning of each measure if `update_period` has a non-zero value.
     - `wave_length` (length, default:`0`)
         - Length of repetition
@@ -497,6 +498,8 @@ Parameter values are written in one of the following formats:
         - Additional requirement:
             - The formats `[float]ms` and `[float]s` are not allowed.
         - `0`: Automatic trigger update is disabled.
+        - This parameter allows kson clients to use only the OnMin value and just ignore the Off and OnMax values.
+        - Note: `update_period` interval count is reset at the beginning of each measure if `update_period` has a non-zero value.
     - `wave_length` (length, default:`0`)
         - Length of repetition
         - `0`: Not specified. (In KSM, the effect is bypassed if the value is `0`. Also, parameter changes to `0` are ignored.)

--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version: `0.3.0-beta2`)
+# KSON Format Specification (version: `0.3.0-beta3`)
 - Encoding: UTF-8 (without BOM), LF
 - If a default value is specified in this document, undefined values are overwritten by the default value.
 - `null` value is not allowed in the entire kson file.
@@ -335,12 +335,11 @@ Leading plus signs (e.g., "`+1`") and scientific notation (e.g., "`1e-3`", "`1E+
             - Requirement: int >= 1
             - Example: `1/2`
         - `[int]%`
-            - Requirement: int >= 0
+            - Requirement: 0 <= int <= 100
             - Example: `50%`
         - `[float]`
-            - Requirement: float >= 0.0
+            - Requirement: 0.0 <= float <= 1.0
             - Example: `0.5`
-    - Note: Some parameters can have values higher than `1.0` (e.g. `flanger.vol`).
 - freq
     - Frequency value (Hz)
     - Allowed formats:

--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version: `0.3.0-beta4`)
+# KSON Format Specification (version: `0.3.0-beta5`)
 - Encoding: UTF-8 (without BOM), LF
 - If a default value is specified in this document, undefined values are overwritten by the default value.
 - `null` value is not allowed in the entire kson file.
@@ -752,6 +752,7 @@ dictionary CompatInfo {
     KshUnknownInfo? ksh_unknown;  // (OPTIONAL) unrecognized data in ksh-to-kson conversion
 }
 ```
+- Note: If the "`ver`" field is not present in the KSH file, `ksh_version` is set to "`100`".
 
 ### `compat.ksh_unknown` (OPTIONAL)
 ```

--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version: `0.2.0`)
+# KSON Format Specification (version: `0.3.0-beta1`)
 - Encoding: UTF-8 (without BOM), LF
 - If a default value is specified in this document, undefined values are overwritten by the default value.
 - `null` value is not allowed in the entire kson file.
@@ -60,9 +60,12 @@ dictionary BeatInfo {
     ByPulse<double>[] bpm;                        // bpm changes
     ByMeasureIndex<TimeSig>[]? time_sig;          // time signature changes
                                                   // this is used for drawing bar lines and audio effects
-    GraphPoint[]? scroll_speed;                   // scroll speed changes (e.g. stop events)
+    Interval[]? stop;                             // stop events
+    ByPulse<double>[]? scroll_speed;              // (OPTIONAL) scroll speed changes (default: 1.0)
 }
 ```
+- Two or more stops cannot be overlapped. To make the chart scroll backwards, set `scroll_speed` to a negative value instead.
+- `stop` has a higher priority than `scroll_speed`.
 
 ### `beat.time_sig`
 ```

--- a/kson_format.md
+++ b/kson_format.md
@@ -136,7 +136,7 @@ dictionary BgmPreviewInfo {
 }
 ```
 
-### `audio.legacy` (OPTIONAL)
+#### `audio.bgm.legacy` (OPTIONAL)
 ```
 dictionary LegacyBgmInfo {
     DOMString[]? fp_filenames;  // filenames of prerendered BGM with audio effects from legacy KSH charts

--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version: `0.3.0-beta5`)
+# KSON Format Specification (version: `0.3.0-beta6`)
 - Encoding: UTF-8 (without BOM), LF
 - If a default value is specified in this document, undefined values are overwritten by the default value.
 - `null` value is not allowed in the entire kson file.
@@ -533,43 +533,43 @@ Parameter values are written in one of the following formats:
     - (`filename` (string))
         - Note that this is not in `v` but at the root of `Def<AudioEffect>`
 - `high_pass_filter`: Bi-quad high-pass filter.
-    - `env` (rate, default:`0%-100%`)
+    - `v` (rate, default:`0%-100%`)
         - Envelope value of the cutoff frequency
-        - Linear transition of the `env` value is translated into a log scale transition when used.
+        - Linear transition of the `v` value is translated into a log scale transition when used.
     - `lo_freq` (freq, default:??? `/*FIXME*/`)
-        - Cutoff frequency when `env` is 0.0
+        - Cutoff frequency when `v` is 0.0
     - `hi_freq` (freq, default:??? `/*FIXME*/`)
-        - Cutoff frequency when `env` is 1.0
+        - Cutoff frequency when `v` is 1.0
     - `q` (float, default:??? `/*FIXME*/`)
         - Q value of the filter
     - `mix` (rate, default:`0%>100%`)
     - Note: `lo_freq` value may exceed the `hi_freq` value.
 - `low_pass_filter`: Bi-quad low-pass filter.
-    - `env` (rate, default:`0%-100%`)
+    - `v` (rate, default:`0%-100%`)
         - Envelope value of the cutoff frequency
-        - Linear transition of the `env` value is translated into a log scale transition when used.
+        - Linear transition of the `v` value is translated into a log scale transition when used.
     - `lo_freq` (freq, default:??? `/*FIXME*/`)
-        - Cutoff frequency when `env` is 0.0
+        - Cutoff frequency when `v` is 0.0
     - `hi_freq` (freq, default:??? `/*FIXME*/`)
-        - Cutoff frequency when `env` is 1.0
+        - Cutoff frequency when `v` is 1.0
     - `q` (float, default:??? `/*FIXME*/`)
         - Q value of the filter
     - `mix` (rate, default:`0%>100%`)
     - Note: `lo_freq` value may exceed the `hi_freq` value.
 - `peaking_filter`: Bi-quad peaking filter.
-    - `env` (rate, default:`0%-100%`)
+    - `v` (rate, default:`0%-100%`)
         - Envelope value of the cutoff frequency
-        - Linear transition of the `env` value is translated into a log scale transition when used.
+        - Linear transition of the `v` value is translated into a log scale transition when used.
     - `lo_freq` (freq, default:??? `/*FIXME*/`)
-        - Cutoff frequency when `env` is 0.0
+        - Cutoff frequency when `v` is 0.0
     - `hi_freq` (freq, default:??? `/*FIXME*/`)
-        - Cutoff frequency when `env` is 1.0
+        - Cutoff frequency when `v` is 1.0
     - `gain` (dB, default:??? `/*FIXME*/`)
         - Gain value of the filter
     - `q` (float, default:??? `/*FIXME*/`)
         - Q value of the filter
     - (OPTIONAL) `delay` (length, default:`0ms`)
-        - Delay time until the `env` value is applied
+        - Delay time until the `v` value is applied
         - Additional requirement:
             - The formats `1/[int]` and `[float]` are not allowed.
             - 0ms <= delay <= 160ms

--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version: `0.3.0-beta6`)
+# KSON Format Specification (version: `0.3.0-beta7`)
 - Encoding: UTF-8 (without BOM), LF
 - If a default value is specified in this document, undefined values are overwritten by the default value.
 - `null` value is not allowed in the entire kson file.
@@ -347,12 +347,6 @@ Leading plus signs (e.g., "`+1`") and scientific notation (e.g., "`1e-3`", "`1E+
             - Requirement: 10 <= int <= 20000
         - `[float]kHz`
             - Requirement: 0.01 <= float <= 20.0
-- dB
-    - Decibel value
-    - Allowed formats:
-        - `[float]dB`
-            - Requirement: float >= 0.0
-            - Example: `3.0dB`
 - pitch
     - Key in music (12 per octave)
     - Allowed formats:
@@ -451,7 +445,7 @@ Parameter values are written in one of the following formats:
     - `mix` (rate, default:`0%>100%`)
         - Blending ratio of the original audio and the effect audio
 - `bitcrusher`: This effect reduces the quality of the audio wave. Also known as "Sample & Hold".
-    - `reduction` (sample, default:`0samples`)
+    - `reduction` (sample, default:`0samples-30samples`)
         - Number of samples to hold. A larger value results in lower sound quality.
     - `mix` (rate, default:`0%>100%`)
         - Blending ratio of the original audio and the effect audio
@@ -535,46 +529,46 @@ Parameter values are written in one of the following formats:
 - `high_pass_filter`: Bi-quad high-pass filter.
     - `v` (rate, default:`0%-100%`)
         - Envelope value of the cutoff frequency
-        - Linear transition of the `v` value is translated into a log scale transition when used.
-    - `lo_freq` (freq, default:??? `/*FIXME*/`)
+        - Note: This parameter is provided to make the frequency transition on a log scale rather than a linear scale.
+    - `freq` (freq, default:`100Hz`)
         - Cutoff frequency when `v` is 0.0
-    - `hi_freq` (freq, default:??? `/*FIXME*/`)
+    - `freq_max` (freq, default:`2200Hz`)
         - Cutoff frequency when `v` is 1.0
     - `q` (float, default:??? `/*FIXME*/`)
-        - Q value of the filter
+        - Q value of the biquad filter
     - `mix` (rate, default:`0%>100%`)
-    - Note: `lo_freq` value may exceed the `hi_freq` value.
+    - Note: `freq` value may exceed the `freq_max` value.
 - `low_pass_filter`: Bi-quad low-pass filter.
     - `v` (rate, default:`0%-100%`)
         - Envelope value of the cutoff frequency
-        - Linear transition of the `v` value is translated into a log scale transition when used.
-    - `lo_freq` (freq, default:??? `/*FIXME*/`)
+        - Note: This parameter is provided to make the frequency transition on a log scale rather than a linear scale.
+    - `freq` (freq, default:`15000Hz`)
         - Cutoff frequency when `v` is 0.0
-    - `hi_freq` (freq, default:??? `/*FIXME*/`)
+    - `freq_max` (freq, default:`800Hz`)
         - Cutoff frequency when `v` is 1.0
     - `q` (float, default:??? `/*FIXME*/`)
-        - Q value of the filter
+        - Q value of the biquad filter
     - `mix` (rate, default:`0%>100%`)
-    - Note: `lo_freq` value may exceed the `hi_freq` value.
+    - Note: `freq` value may exceed the `freq_max` value.
 - `peaking_filter`: Bi-quad peaking filter.
     - `v` (rate, default:`0%-100%`)
         - Envelope value of the cutoff frequency
-        - Linear transition of the `v` value is translated into a log scale transition when used.
-    - `lo_freq` (freq, default:??? `/*FIXME*/`)
+        - Note: This parameter is provided to make the frequency transition on a log scale rather than a linear scale.
+    - `freq` (freq, default:`50Hz`)
         - Cutoff frequency when `v` is 0.0
-    - `hi_freq` (freq, default:??? `/*FIXME*/`)
+    - `freq_max` (freq, default:`9000Hz`)
         - Cutoff frequency when `v` is 1.0
-    - `gain` (dB, default:??? `/*FIXME*/`)
-        - Gain value of the filter
-    - `q` (float, default:??? `/*FIXME*/`)
-        - Q value of the filter
+    - `gain` (rate, default:`50%`)
+        - Gain scale
+    - `q` (float, default:`1.2`)
+        - Q value of the biquad filter
     - (OPTIONAL) `delay` (length, default:`0ms`)
         - Delay time until the `v` value is applied
         - Additional requirement:
             - The formats `1/[int]` and `[float]` are not allowed.
             - 0ms <= delay <= 160ms
     - `mix` (rate, default:`0%>100%`)
-    - Note: `lo_freq` value may exceed the `hi_freq` value.
+    - Note: `freq` value may exceed the `freq_max` value.
 
 -----------------------------------------------------------------------------------
 

--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version: `0.3.0-beta9`)
+# KSON Format Specification (version: `0.3.0`)
 - Encoding: UTF-8 (without BOM), LF
 - If a default value is specified in this document, undefined values are overwritten by the default value.
 - `null` value is not allowed in the entire kson file.


### PR DESCRIPTION
Changes:
- Updated value constraints and some notes
- Added two major categories: `editor` (currently only comments) and `compat` (information for compatibility with KSH)
- Filled in missing default values for audio effect parameters
    - (Q values for high-pass and low-pass filters are still missing)
- Changed `bitcrusher` default value: `reduction:"0samples"` -> `reduction:"0samples-30samples"`
- Defined "filename" as the type of audio effect parameter
    - Parameter values are now strings, so they no longer need to be separated.
- Parameter name changes: `env`->`v`, `lo_freq`/`hi_freq`->`freq`/`freq_max`.
- Parameter type changes: `gain`(peaking_filter) dB->rate