### PR TITLE
kson format v0.9.0

### DIFF
--- a/kson_format.md
+++ b/kson_format.md
@@ -744,12 +744,11 @@ dictionary CamPatternInvokeSwingValue {
 ```
 dictionary BGInfo {
     filename: string?      // (OPTIONAL SUPPORT) filename of background graphics file
-    offset:   int = 0      // (OPTIONAL SUPPORT) movie offset in millisecond
     legacy: LegacyBGInfo?  // (OPTIONAL SUPPORT)
 }
 ```
 - Note: The file format of `bg.filename` is not specified. If the format of the file specified in `bg.filename` is supported by the kson client, `bg.filename` is used; otherwise, it falls back to other built-in background graphics (which MAY be specified in `legacy`).
-- Note: `bg.offset` is used only if supported by the BG file format and its player, the kson client.
+- Note: `bg.filename` is reserved for future extension and is currently not used by KSM v2.
 
 ### `bg.legacy` (OPTIONAL SUPPORT)
 ```

--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version: `0.9.0-beta1`)
+# KSON Format Specification (version: `0.9.0-beta2`)
 ## Basic Specifications
 - **JSON format**: KSON files MUST use the JSON format.
 - **File extension**: KSON files MUST use the `.kson` file extension.
@@ -64,6 +64,7 @@ dictionary BeatInfo {
     bpm:          ByPulse<double>[]                       // bpm changes
     time_sig:     ByMeasureIdx<TimeSig>[] = [[0, [4, 4]]] // time signature changes
     scroll_speed: GraphPoint[] = [[0, 1.0]]               // scroll speed changes
+    stop:         ByPulse<RelPulse>[]?                    // stops (equivalent to setting scroll_speed to 0 for a duration)
 }
 ```
 
@@ -74,6 +75,15 @@ array TimeSig {
     [1]: uint  // denominator
 }
 ```
+
+### `beat.stop[xxx]`
+```
+array ByPulse<RelPulse> {
+    [0]: uint  // y: pulse number
+    [1]: uint  // v: stop duration (relative pulse)
+}
+```
+- Note: If both `stop` and `scroll_speed` are specified at the same position, `stop` has higher priority.
 
 -----------------------------------------------------------------------------------
 
@@ -501,7 +511,7 @@ Parameter values are written in one of the following formats:
             - 0.1 <= float <= 50.0
     - `feedback` (rate, default:`35%`)
         - Feedback rate
-    - `stereo_width` (rate, default:`0%`)
+    - `stereo_width` (rate, default:`75%`)
         - LFO phase difference between the L/R channels
     - (OPTIONAL SUPPORT) `hi_cut_gain` (float, default:`-8.0`)
         - Gain reduction (in dB) for frequencies above the center of `freq_1` and `freq_2` (≤0.0)
@@ -951,11 +961,14 @@ array GraphSectionPoint {
 
 # Change Log
 
+- `0.9.0-beta2`
+    - Added `beat.stop` parameter to represent chart stops separately from `scroll_speed`
 - `0.9.0-beta1`
     - Camera field names changed to match KSH format: `rotation_x` → `zoom_top`, `shift_x` → `zoom_side`, `zoom` → `zoom_bottom`
     - Camera value scales changed to match KSH format (removed scale conversions)
     - Swing scale default changed from 1.0 to 250.0 to match KSH format
     - Re-added parameters as OPTIONAL SUPPORT (previously removed): `pitch_shift.chunk_size`, `pitch_shift.overlap`, `phaser.hi_cut_gain`
+    - Fix default value for `phaser.stereo_width`
 - `0.8.0` (08/13/2023)
     - Changes: https://github.com/kshootmania/ksm-chart-format/pull/13/files
 - [`0.7.1`](https://github.com/kshootmania/ksm-chart-format/blob/51c260bb16fe47afd2366fd04abddfbc36ca34ff/kson_format.md) (07/22/2023)

--- a/kson_format.md
+++ b/kson_format.md
@@ -357,7 +357,7 @@ Leading plus signs (e.g., "`+1`") and scientific notation (e.g., "`1e-3`", "`1E+
         - For example, `44100samples` means 1.0s
     - Allowed formats:
         - `[int]samples`
-            - Requirement: 1 <= int <= 44100
+            - Requirement: 0 <= int <= 44100
             - Example: `40samples`
     - The trailing "s" cannot be omitted even if the value is 1 (i.e., "`1sample`" is illegal, use "`1samples`" instead).
 - switch
@@ -490,6 +490,8 @@ Parameter values are written in one of the following formats:
         - Larger values improve sound quality but increase latency
     - (OPTIONAL SUPPORT) `overlap` (rate, default:`40%`)
         - Cross-fade ratio for smoothly connecting samples after chunk stretching/compression (0%-50%)
+        - Additional requirement:
+            - 0.0 <= float <= 0.5
         - Larger values produce smoother sound but may cause wave interference
     - `mix` (rate, default:`0%>100%`)
         - Blending ratio of the original audio and the effect audio
@@ -596,6 +598,8 @@ Parameter values are written in one of the following formats:
         - Cutoff frequency when `v` is 1.0
     - (OPTIONAL SUPPORT) `bandwidth` (float, default:implementation-dependent)
         - Bandwidth around the cutoff frequency [oct]
+        - Additional requirement:
+            - 0.1 <= float <= 10.0
     - `gain` (rate, default:`50%`)
         - Gain scale
     - `mix` (rate, default:`0%>100%`)
@@ -627,7 +631,7 @@ Parameter values are written in one of the following formats:
     - (OPTIONAL SUPPORT) `q` (float, default:implementation-dependent)
         - Q value of the biquad filter
         - Additional requirement:
-            - 0.1 <= float <= 5.0
+            - 0.1 <= float <= 50.0
     - `mix` (rate, default:`0%>100%`)
         - Blending ratio of the original audio and the effect audio
     - Note: `freq` value may exceed the `freq_max` value.

--- a/kson_format.md
+++ b/kson_format.md
@@ -271,9 +271,17 @@ dictionary AudioEffectLaserInfo {
     param_change: dictionary<dictionary<ByPulse<string>[]>>? // audio effect parameter changes by pulse
     pulse_event: dictionary<uint[]>?                         // audio effect invocation by pulse
     peaking_filter_delay: uint = 0                           // (OPTIONAL SUPPORT) peaking filter delay time in milliseconds (0-160)
+    legacy: AudioEffectLaserLegacyInfo?                      // (OPTIONAL SUPPORT) legacy information
 }
 ```
 - Note: `audio.audio_effect.laser.pulse_event` cannot contain parameter changes. Use `audio.audio_effect.laser.param_change` instead.
+
+##### `audio.audio_effect.laser.legacy` (OPTIONAL SUPPORT)
+```
+dictionary AudioEffectLaserLegacyInfo {
+    filter_gain: ByPulse<double>[] = [[0, 0.5]]  // filter gain (0.0-1.0); "pfiltergain" in KSH format
+}
+```
 
 ##### `audio.audio_effect.fx.def.xxx`/`audio.audio_effect.laser.def.xxx`
 ```

--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version: `0.8.0`)
+# KSON Format Specification (version: `0.9.0-beta1`)
 ## Basic Specifications
 - **JSON format**: KSON files MUST use the JSON format.
 - **File extension**: KSON files MUST use the `.kson` file extension.
@@ -470,9 +470,14 @@ Parameter values are written in one of the following formats:
 - `pitch_shift`: This effect changes the pitch (key) of the audio.
     - `pitch` (pitch, default:`0`)
         - Pitch (key)
+    - (OPTIONAL SUPPORT) `chunk_size` (sample, default:`700samples`)
+        - Chunk size for pitch shifting
+        - Larger values improve sound quality but increase latency
+    - (OPTIONAL SUPPORT) `overlap` (rate, default:`40%`)
+        - Cross-fade ratio for smoothly connecting samples after chunk stretching/compression (0%-50%)
+        - Larger values produce smoother sound but may cause wave interference
     - `mix` (rate, default:`0%>100%`)
         - Blending ratio of the original audio and the effect audio
-    - Note: `chunkSize` and `overWrap` (properly "overlap") parameters in KSH format has been removed in kson format because they assume that the audio waveform is processed in the time domain.
 - `bitcrusher`: This effect reduces the quality of the audio wave. Also known as "Sample & Hold".
     - `reduction` (sample, default:`0samples-30samples`)
         - Number of samples to hold. A larger value results in lower sound quality.
@@ -498,11 +503,14 @@ Parameter values are written in one of the following formats:
         - Feedback rate
     - `stereo_width` (rate, default:`0%`)
         - LFO phase difference between the L/R channels
+    - (OPTIONAL SUPPORT) `hi_cut_gain` (float, default:`-8.0`)
+        - Gain reduction (in dB) for frequencies above the center of `freq_1` and `freq_2` (≤0.0)
+        - Additional requirement:
+            - float <= 0.0
     - `mix` (rate, default:`0%>50%`)
         - Blending ratio of the original audio and the effect audio
         - Note: For phaser effects, the mix value is doubled when used. A typical phaser effect is usually most effective at a mix value of 50%, but this makes it most effective at a mix value of `100%`. Note that the default value `50%` is actually a mix value of 25%.
     - Note: `freq_1` value may exceed the `freq_2` value.
-    - Note: `hiCutGain` parameter in KSH format has been removed in kson format because it is not a parameter of the phaser itself.
 - `wobble`: This effect oscillates the cutoff frequency of the low-pass filter with an LFO.
     - `wave_length` (length, default:`0`)
         - LFO period
@@ -643,15 +651,15 @@ dictionary CamInfo {
 #### `camera.cam.body`
 ```
 dictionary CamGraphs {
-    zoom:               GraphPoint[]?  // move the bottom edge closer to the camera (zoom_bottom in KSH format)
-    shift_x:            GraphPoint[]?  // move the highway horizontally (zoom_side in KSH format)
-    rotation_x:         GraphPoint[]?  // rotate the upper edge around the judgment line (zoom_top in KSH format)
+    zoom_top:           GraphPoint[]?  // rotate the upper edge around the judgment line (zoom_top in KSH format)
+    zoom_bottom:        GraphPoint[]?  // move the bottom edge closer to the camera (zoom_bottom in KSH format)
+    zoom_side:          GraphPoint[]?  // move the highway horizontally (zoom_side in KSH format)
     rotation_z:         GraphPoint[]?  // rotation degree (affects both highway & jdgline relatively)
     center_split:       GraphPoint[]?  // split the highway at the center (center_split in KSH format)
 }
 ```
-- The value scale used for `zoom`/`shift_x`/`rotation_x`/`center_split` is identical to the scale used for `zoom_bottom`/`zoom_side`/`zoom_top`/`center_split` in KSH format.
-- The units used for the `rotation_x` value are not degrees, but instead represent one full rotation every +2400 units.
+- The value scale used for `zoom_top`/`zoom_bottom`/`zoom_side`/`center_split` is identical to the scale used in KSH format.
+- The units used for the `zoom_top` value are not degrees, but instead represent one full rotation every +2400 units.
 
 #### `camera.cam.pattern`
 ```
@@ -702,7 +710,7 @@ array CamPatternInvokeSwing {
 ##### `camera.cam.pattern.laser.slam_event.swing[][3]` (OPTIONAL SUPPORT)
 ```
 dictionary CamPatternInvokeSwingValue {
-    scale:  double = 1.0   // scale
+    scale:  double = 250.0 // scale
     repeat: uint = 1       // number of repetitions
     decay_order: uint = 0  // order of the decay that scales camera values (0-2)
                            // (note that this decay is applied even if repeat=1)
@@ -943,6 +951,11 @@ array GraphSectionPoint {
 
 # Change Log
 
+- `0.9.0-beta1`
+    - Camera field names changed to match KSH format: `rotation_x` → `zoom_top`, `shift_x` → `zoom_side`, `zoom` → `zoom_bottom`
+    - Camera value scales changed to match KSH format (removed scale conversions)
+    - Swing scale default changed from 1.0 to 250.0 to match KSH format
+    - Re-added parameters as OPTIONAL SUPPORT (previously removed): `pitch_shift.chunk_size`, `pitch_shift.overlap`, `phaser.hi_cut_gain`
 - `0.8.0` (08/13/2023)
     - Changes: https://github.com/kshootmania/ksm-chart-format/pull/13/files
 - [`0.7.1`](https://github.com/kshootmania/ksm-chart-format/blob/51c260bb16fe47afd2366fd04abddfbc36ca34ff/kson_format.md) (07/22/2023)

--- a/kson_format.md
+++ b/kson_format.md
@@ -402,6 +402,11 @@ Leading plus signs (e.g., "`+1`") and scientific notation (e.g., "`1e-3`", "`1E+
     - Allowed formats:
         - `[float]`
             - Example: `2.5`, `-10`
+- dB
+    - Decibel value
+    - Allowed formats:
+        - `[float]dB`
+            - Example: `-8.0dB`, `0dB`, `3.5dB`
 - filename
     - Filename string
     - Parameter values of this type can only be specified in `audio.audio_effect.xxx.def` and cannot be changed via `param_change`/`long_event`.
@@ -513,8 +518,8 @@ Parameter values are written in one of the following formats:
         - Feedback rate
     - `stereo_width` (rate, default:`75%`)
         - LFO phase difference between the L/R channels
-    - (OPTIONAL SUPPORT) `hi_cut_gain` (float, default:`-8.0`)
-        - Gain reduction (in dB) for frequencies above the center of `freq_1` and `freq_2` (≤0.0)
+    - (OPTIONAL SUPPORT) `hi_cut_gain` (dB, default:`-8.0dB`)
+        - Gain reduction for frequencies above the center of `freq_1` and `freq_2`
         - Additional requirement:
             - float <= 0.0
     - `mix` (rate, default:`0%>50%`)

--- a/kson_format.md
+++ b/kson_format.md
@@ -248,6 +248,7 @@ dictionary AudioEffectFXInfo {
     long_event:   dictionary<(uint|ByPulse<dictionary<string>>)[][2]>? // audio effect invocation (and parameter changes) by long notes
 }
 ```
+- Note: `def` is an array of key-value pairs to preserve the order in which the user created the definitions, ensuring a stable order during editing and processing.
 - Note: `y` (pulse number) of `long_event` should be in the range `[y, y + length)` of an existing long FX note on the corresponding lane; otherwise, the event is ignored.
 - Example for `audio.audio_effect.fx.param_change`/`audio.audio_effect.laser.param_change`:
     ```
@@ -267,13 +268,14 @@ dictionary AudioEffectFXInfo {
 #### `audio.audio_effect.laser`
 ```
 dictionary AudioEffectLaserInfo {
-    def: dictionary<AudioEffectDef>?                         // audio effect definitions
+    def: DefKeyValuePair<AudioEffectDef>[]?                  // audio effect definitions
     param_change: dictionary<dictionary<ByPulse<string>[]>>? // audio effect parameter changes by pulse
     pulse_event: dictionary<uint[]>?                         // audio effect invocation by pulse
     peaking_filter_delay: uint = 0                           // (OPTIONAL SUPPORT) peaking filter delay time in milliseconds (0-160)
     legacy: AudioEffectLaserLegacyInfo?                      // (OPTIONAL SUPPORT) legacy information
 }
 ```
+- Note: `def` is an array of key-value pairs to preserve the order in which the user created the definitions, ensuring a stable order during editing and processing.
 - Note: `audio.audio_effect.laser.pulse_event` cannot contain parameter changes. Use `audio.audio_effect.laser.param_change` instead.
 
 ##### `audio.audio_effect.laser.legacy` (OPTIONAL SUPPORT)

--- a/kson_format.md
+++ b/kson_format.md
@@ -17,17 +17,17 @@
 ## Top-level object
 ```
 dictionary kson {
-    version: string       // kson version (Semantic Versioning like "x.y.z")
-    meta:    MetaInfo     // meta data, e.g. title, artist, ...
-    beat:    BeatInfo     // beat-related data, e.g. bpm, time signature, ...
-    gauge:   GaugeInfo?   // gauge-related data
-    note:    NoteInfo?    // notes on each lane
-    audio:   AudioInfo?   // audio-related data
-    camera:  CameraInfo?  // camera-related data
-    bg:      BGInfo?      // background-related data
-    editor:  EditorInfo?  // (OPTIONAL SUPPORT) data used only in editors
-    compat:  CompatInfo?  // (OPTIONAL SUPPORT) compatibility data with KSH format
-    impl:    ImplInfo?    // (OPTIONAL SUPPORT) data that is sure to be for a specific client
+    format_version: uint      // kson format version number (1 for kson 0.9.0, incremented by 1 for each format update)
+    meta:    MetaInfo         // meta data, e.g. title, artist, ...
+    beat:    BeatInfo         // beat-related data, e.g. bpm, time signature, ...
+    gauge:   GaugeInfo?       // gauge-related data
+    note:    NoteInfo?        // notes on each lane
+    audio:   AudioInfo?       // audio-related data
+    camera:  CameraInfo?      // camera-related data
+    bg:      BGInfo?          // background-related data
+    editor:  EditorInfo?      // (OPTIONAL SUPPORT) data used only in editors
+    compat:  CompatInfo?      // (OPTIONAL SUPPORT) compatibility data with KSH format
+    impl:    ImplInfo?        // (OPTIONAL SUPPORT) data that is sure to be for a specific client
 }
 ```
 
@@ -664,7 +664,7 @@ dictionary CamGraphs {
     zoom_top:           GraphPoint[]?  // rotate the upper edge around the judgment line (zoom_top in KSH format)
     zoom_bottom:        GraphPoint[]?  // move the bottom edge closer to the camera (zoom_bottom in KSH format)
     zoom_side:          GraphPoint[]?  // move the highway horizontally (zoom_side in KSH format)
-    rotation_z:         GraphPoint[]?  // rotation degree (affects both highway & jdgline relatively)
+    rotation_deg:       GraphPoint[]?  // rotation degree (affects both highway & jdgline relatively)
     center_split:       GraphPoint[]?  // split the highway at the center (center_split in KSH format)
 }
 ```

--- a/kson_format.md
+++ b/kson_format.md
@@ -189,7 +189,7 @@ dictionary KeySoundInvokeListFX {
     snare:       (uint|ByPulse<KeySoundInvokeFX>)[][2]?  // (OPTIONAL SUPPORT)
     snare_lo:    (uint|ByPulse<KeySoundInvokeFX>)[][2]?  // (OPTIONAL SUPPORT)
 
-    ...:         (uint|ByPulse<KeySoundInvokeFX>)[][2]?  // Custom key sounds can be inserted here by using the filename of a WAVE file (.wav) as a key
+    ...:         (uint|ByPulse<KeySoundInvokeFX>)[][2]?  // Custom key sounds can be inserted here by using an audio filename (with extension) as a key
 }
 ```
 - Note: `y` (pulse number) should be the same as `y` of an existing chip FX note; otherwise, the event is ignored.
@@ -219,7 +219,7 @@ dictionary KeySoundInvokeListLaser {
     slam_swing: uint[]?  // (OPTIONAL SUPPORT)
     slam_mute:  uint[]?  // (OPTIONAL SUPPORT)
 
-    // Note: Inserting custom key sounds here is not allowed
+    ...:        uint[]?  // Custom key sounds can be inserted here by using an audio filename (with extension) as a key
 }
 ```
 - Note: `y` (pulse number) should be the same as `y` of an existing laser slam note; otherwise, the event is ignored.

--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version: `0.9.0-beta2`)
+# KSON Format Specification (version 0.9.0, format_version: `1`)
 ## Basic Specifications
 - **JSON format**: KSON files MUST use the JSON format.
 - **File extension**: KSON files MUST use the `.kson` file extension.
@@ -1029,15 +1029,9 @@ array GraphSectionPoint {
 
 # Change Log
 
-- `0.9.0-beta2`
-    - Added `beat.stop` parameter to represent chart stops separately from `scroll_speed`
-- `0.9.0-beta1`
-    - Camera field names changed to match KSH format: `rotation_x` → `zoom_top`, `shift_x` → `zoom_side`, `zoom` → `zoom_bottom`
-    - Camera value scales changed to match KSH format (removed scale conversions)
-    - Swing scale default changed from 1.0 to 250.0 to match KSH format
-    - Re-added parameters as OPTIONAL SUPPORT (previously removed): `pitch_shift.chunk_size`, `pitch_shift.overlap`, `phaser.hi_cut_gain`
-    - Fix default value for `phaser.stereo_width`
-- `0.8.0` (08/13/2023)
+- `0.9.0` (11/16/2025)
+    - Changes: https://github.com/kshootmania/ksm-chart-format/pull/14/files
+- [`0.8.0`](https://github.com/kshootmania/ksm-chart-format/blob/2b917d8876e4cb2cce4a39cfdb1b714a0a8df0ea/kson_format.md) (08/13/2023)
     - Changes: https://github.com/kshootmania/ksm-chart-format/pull/13/files
 - [`0.7.1`](https://github.com/kshootmania/ksm-chart-format/blob/51c260bb16fe47afd2366fd04abddfbc36ca34ff/kson_format.md) (07/22/2023)
     - Changes: https://github.com/kshootmania/ksm-chart-format/pull/12/files

--- a/kson_format.md
+++ b/kson_format.md
@@ -980,7 +980,7 @@ array GraphValue {
 ```
 - The array size of `GraphValue` MUST be 2.
 
-### graph curve value (OPTIONAL SUPPORT)
+### graph curve value
 ```
 array GraphCurveValue {
     [0]: double  // a: x-coordinate of the curve control point (0.0-1.0)
@@ -994,7 +994,7 @@ array GraphCurveValue {
 array GraphPoint {
     [0]: uint                          // y: absolute pulse number
     [1]: double|GraphValue             // v: graph value; if double is used, v and vf are set to the same value
-    [2]: GraphCurveValue = [0.0, 0.0]  // (OPTIONAL SUPPORT) curve: graph curve value
+    [2]: GraphCurveValue = [0.0, 0.0]  // curve: graph curve value
 }
 ```
 - The array size of `GraphPoint<T>` MUST be 2 or 3.
@@ -1004,7 +1004,7 @@ array GraphPoint {
 array GraphSectionPoint {
     [0]: uint                          // ry: relative pulse number
     [1]: double|GraphValue             // v: graph value; if double is used, v and vf are set to the same value
-    [2]: GraphCurveValue = [0.0, 0.0]  // (OPTIONAL SUPPORT) curve: graph curve value
+    [2]: GraphCurveValue = [0.0, 0.0]  // curve: graph curve value
 }
 ```
 - The array size of `GraphSectionPoint<T>` MUST be 2 or 3.

--- a/kson_format.md
+++ b/kson_format.md
@@ -655,7 +655,7 @@ dictionary CameraInfo {
     cam:  CamInfo?  // cam-related data
 }
 
-type TiltValue = string|double|[double,double]|[double,[double,double]]|[[double,double],[double,double]]
+type TiltValue = string|double|[double,double]|[double,string]|[double,[double,double]]|[[double,double],[double,double]]
 ```
 
 ### `camera.tilt`
@@ -685,6 +685,14 @@ type TiltValue = string|double|[double,double]|[double,[double,double]]|[[double
   - Format in ByPulse: `[y, [v, vf]]`
   - Immediate change from `v` to `vf` at the same pulse
   - Example: `[960, [0.5, 0.8]]` means tilt changes from 0.5 to 0.8 instantly at pulse 960
+
+- **`[double, string]`**: Manual tilt to auto tilt with immediate change
+  - Format in ByPulse: `[y, [v, vf]]`
+  - `v`: Manual tilt value (double)
+  - `vf`: Auto tilt type (string)
+  - Requirement: -100.0 <= v <= 100.0
+  - Requirement: vf must be one of: "normal", "bigger", "biggest", "keep_normal", "keep_bigger", "keep_biggest", "zero"
+  - Example: `[960, [0.8, "normal"]]` means tilt changes from manual value 0.8 to auto tilt "normal" instantly at pulse 960
 
 - **`[double, [double, double]]`**: Manual tilt with curve (no immediate change)
   - Format in ByPulse: `[y, [v, [a, b]]]`


### PR DESCRIPTION
- Version management
    - `format_version` (uint) is added
      - `format_version` is `1` for kson 0.9.0
      - `format_version` is incremented when breaking changes are introduced or new fields are added that may cause data loss when opening newer charts in older editors
    - `version` (string) is removed

- `beat.stop` is added
    - Note: Equivalent to setting `scroll_speed` to 0 for a duration, added for improved compatibility with KSH format conversion

- Custom audio filenames
    - `audio.key_sound.fx.xxx`: The note now clarifies "audio filename (with extension)" instead of "filename of a WAVE file (.wav)"
    - `audio.key_sound.laser.slam_event`: Custom key sounds can now be inserted by using an audio filename (with extension) as a key

- `audio.audio_effect.laser.def` type is fixed from `dictionary<AudioEffectDef>` to `DefKeyValuePair<AudioEffectDef>[]` to preserve the order of definitions

- `audio.audio_effect.laser.legacy` (OPTIONAL SUPPORT) is added
    - `filter_gain` (default: `[[0, 0.5]]`): Filter gain (0.0-1.0); "pfiltergain" in KSH format

- Audio effect parameters
    - `sample` type: The requirement is changed from `1 <= int <= 44100` to `0 <= int <= 44100`
    - `pitch_shift`: `chunk_size` (OPTIONAL SUPPORT) and `overlap` (OPTIONAL SUPPORT) are re-added
    - `phaser`:
        - The default value of `stereo_width` is fixed from `0%` to `75%`
        - `hi_cut_gain` (OPTIONAL SUPPORT, dB, default: `-8.0dB`) is re-added, and parameter type `dB` is added
    - `peaking_filter`: `bandwidth` requirement `0.1 <= float <= 10.0` is specified
    - `high_pass_filter`: `q` requirement is fixed from `0.1 <= float <= 5.0` to `0.1 <= float <= 50.0`

- `camera.tilt` structure changed
    - Old structure (`TiltInfo` with `scale`/`manual`/`keep`) is replaced with `ByPulse<TiltValue>`
    - `TiltValue` is a union type: `string|double|[double,double]|[double,string]|[double,[double,double]]|[[double,double],[double,double]]`
    - Supports auto tilt types (string), manual tilt values (double), immediate changes, and manual-to-auto transitions
    - Note: This fixes the v0.8.0 limitation that could not represent KSH charts where the final `tilt=` option specifies a manual tilt value (which persists beyond the chart end)

- `camera.cam.body`
    - `zoom`/`shift_x`/`rotation_x` are renamed as `zoom_bottom`/`zoom_side`/`zoom_top`
    - `rotation_z` is renamed as `rotation_deg`
    - Note: The value scales for these parameters are now explicitly specified to match KSH format (no scale conversion needed)

- `camera.cam.pattern.laser.slam_event.swing[][3]`: The default value of `scale` is changed from `1.0` to `250.0`
    - Note: Changed to match KSH format's default swing scale value

- `bg.offset` is removed

- `bg.filename`: A note is added that it is reserved for future extension and is currently not referenced by KSM v2

- Graph curve values are no longer marked as "(OPTIONAL SUPPORT)" in `GraphPoint` and `GraphSectionPoint`