### PR TITLE
kson format v1.0.0

### DIFF
--- a/kson_format.md
+++ b/kson_format.md
@@ -284,6 +284,11 @@ dictionary AudioEffectLaserLegacyInfo {
     filter_gain: ByPulse<double>[] = [[0, 0.5]]  // filter gain (0.0-1.0); "pfiltergain" in KSH format
 }
 ```
+- Note: `filter_gain` serves as a shorthand for controlling multiple built-in filter effects' parameters via `audio.audio_effect.laser.param_change`.
+    - In KSM v2, `filter_gain` is converted to the following parameters only when the corresponding built-in effects are not overridden by user-defined effects in `audio.audio_effect.laser.def`:
+        - `peaking_filter.gain`: linear interpolation between `0%` and `100%`
+        - `high_pass_filter.q`: linear interpolation between `2.0` and `8.0`
+        - `low_pass_filter.q`: linear interpolation between `2.0` and `5.2`
 
 ##### `audio.audio_effect.fx.def.xxx`/`audio.audio_effect.laser.def.xxx`
 ```

--- a/kson_format.md
+++ b/kson_format.md
@@ -943,7 +943,7 @@ dictionary KSHUnknownInfo {
             "line":[
                 [0, ";some-extension1"],
                 [0, ";some-extension2"],
-                [960, ";some-extension3"],
+                [960, ";some-extension3"]
             ]
         }
         ```

--- a/kson_format.md
+++ b/kson_format.md
@@ -1016,7 +1016,7 @@ array GraphPoint {
     [2]: GraphCurveValue = [0.0, 0.0]  // curve: graph curve value
 }
 ```
-- The array size of `GraphPoint<T>` MUST be 2 or 3.
+- The array size of `GraphPoint` MUST be 2 or 3.
 
 ### graph point (for graph sections = `ByPulse<GraphSectionPoint[]>`)
 ```
@@ -1026,7 +1026,7 @@ array GraphSectionPoint {
     [2]: GraphCurveValue = [0.0, 0.0]  // curve: graph curve value
 }
 ```
-- The array size of `GraphSectionPoint<T>` MUST be 2 or 3.
+- The array size of `GraphSectionPoint` MUST be 2 or 3.
 
 -----------------------------------------------------------------------------------
 

--- a/kson_format.md
+++ b/kson_format.md
@@ -683,6 +683,7 @@ type TiltValue = string|double|[double,double]|[double,string]|[double,[double,d
   - Specifies the tilt amount
   - Requirement: -100.0 <= value <= 100.0
   - Note: The left laser being on the right edge is equal to a manual value of 1.0, and the right laser being on the left edge is equal to a manual value of -1.0.
+      - The value ±1.0 represents the normal maximum tilt range, and the limit of ±100.0 allows up to 10000% of this range.
   - Note: Manual tilt is always evaluated with a scale of 1.0 (independent of auto tilt scale)
   - Example: `[960, 0.5]` means tilt interpolates to 0.5 with linear interpolation
 

--- a/kson_format.md
+++ b/kson_format.md
@@ -744,6 +744,11 @@ dictionary CamGraphs {
 ```
 - The value scale used for `zoom_top`/`zoom_bottom`/`zoom_side`/`center_split` is identical to the scale used in KSH format.
 - The units used for the `zoom_top` value are not degrees, but instead represent one full rotation every +2400 units.
+- Valid value ranges:
+    - `zoom_top`, `zoom_bottom`, `zoom_side`: [-65535.0, 65535.0]
+    - `center_split`: [-65535.0, 65535.0]
+    - `rotation_deg`: [-65535.0, 65535.0] (in degrees)
+- Values outside these ranges MAY be clamped by KSON clients.
 
 #### `camera.cam.pattern`
 ```

--- a/kson_format.md
+++ b/kson_format.md
@@ -800,8 +800,8 @@ array CamPatternInvokeSwing {
 ```
 dictionary CamPatternInvokeSwingValue {
     scale:  double = 250.0 // scale
-    repeat: uint = 1       // number of repetitions
-    decay_order: uint = 0  // order of the decay that scales camera values (0-2)
+    repeat: uint = 3       // number of repetitions
+    decay_order: uint = 2  // order of the decay that scales camera values (0-2)
                            // (note that this decay is applied even if repeat=1)
                            // - equation: `value * (1.0 - ((l - ry) / l))^decay_order`
                            // - 0: no decay, 1: linear decay, 2: squared decay

--- a/kson_format.md
+++ b/kson_format.md
@@ -1,4 +1,4 @@
-# KSON Format Specification (version 0.9.0, format_version: `1`)
+# KSON Format Specification (version 1.0.0, format_version: `1`)
 ## Basic Specifications
 - **JSON format**: KSON files MUST use the JSON format.
 - **File extension**: KSON files MUST use the `.kson` file extension.
@@ -17,7 +17,7 @@
 ## Top-level object
 ```
 dictionary kson {
-    format_version: uint      // kson format version number (1 for kson 0.9.0, incremented by 1 for each format update)
+    format_version: uint      // kson format version number (1 for kson 1.0.0, incremented by 1 for each format update)
     meta:    MetaInfo         // meta data, e.g. title, artist, ...
     beat:    BeatInfo         // beat-related data, e.g. bpm, time signature, ...
     gauge:   GaugeInfo?       // gauge-related data
@@ -1040,7 +1040,9 @@ array GraphSectionPoint {
 
 # Change Log
 
-- `0.9.0` (11/16/2025)
+- `1.0.0` (02/11/2026)
+    - Changes: https://github.com/kshootmania/ksm-chart-format/pull/15/files
+- [`0.9.0`](https://github.com/kshootmania/ksm-chart-format/blob/45e2b14141b3f65fe70fe984ef574cb8a0bcb201/kson_format.md) (11/16/2025)
     - Changes: https://github.com/kshootmania/ksm-chart-format/pull/14/files
 - [`0.8.0`](https://github.com/kshootmania/ksm-chart-format/blob/2b917d8876e4cb2cce4a39cfdb1b714a0a8df0ea/kson_format.md) (08/13/2023)
     - Changes: https://github.com/kshootmania/ksm-chart-format/pull/13/files


### PR DESCRIPTION
Changes
                                                                                                                                                                                             
- `camera`                                                                                                                                                                                                            
  - `camera.cam.pattern.laser.slam_event.swing[][3]`: Default values are corrected                                                                                                                                                       
    - `repeat`: Corrected from `1` to `3`                                                                                                                                                                                                  
    - `decay_order`: Corrected from `0` to `2`
  - `camera.cam.body`: Valid value range [-65535.0, 65535.0] is now explicitly specified
  - `camera.tilt` manual tilt value: Additional note is added explaining the behavior

- `audio`
  - `audio.audio_effect.laser.legacy.filter_gain`: Additional note is added explaining the behavior

- Documentation fixes
  - Invalid type parameter notation removed from array size specification
    - `GraphPoint<T>` → `GraphPoint`
    - `GraphSectionPoint<T>` → `GraphSectionPoint`
  - Invalid trailing comma removed from JSON example in `compat.ksh_unknown`